### PR TITLE
Fix Build Docs Workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
fix(workflows.build-docs): Correct checkout to fetch tags and default branch to correctly build all versions of documentation.