### PR TITLE
Use Sphinx < v9 to avoid unsupported breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ benchmatcha = "BenchMatcha.runner:main"
 
 [project.optional-dependencies]
 dev = ["BenchMatcha[commit,doc,test,lint,type]"]
-doc = ["sphinx", "furo", "sphinx_multiversion"]
+# NOTE: Sphinx v9.0.0 introduced several breaking changes, including
+#       incompatibility with Sphinx multiversion project, see:
+# https://github.com/sphinx-contrib/multiversion/issues/201
+doc = ["sphinx<9.0.0", "furo", "sphinx_multiversion"]
 test = ["pytest", "coverage>=7.10.3", "pytest-xdist", "tox"]
 commit = ["pre-commit"]
 lint = ["pylint", "ruff"]


### PR DESCRIPTION
Fix documentation build by (hopefully temporarily) avoiding v9 Sphinx dependency, due to breaking changes. See [Sphinx v9 release notes](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0#Incompatible%20changes), and [outstanding issue at sphinx-multiversion](https://github.com/sphinx-contrib/multiversion/issues/201), which does not currently support Sphinx v9+.